### PR TITLE
Unicode format bug

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -338,7 +338,7 @@ class FlexMock(object):
 
   def should_call(self, method):
     """Shortcut for creating a spy.
-    
+
     Alias for should_receive().and_execute.
     """
     return self.should_receive(method).and_execute
@@ -588,7 +588,7 @@ class FlexMock(object):
   @staticmethod
   def _format_args(method, arguments):
     def to_str(arg):
-      if isinstance(arg, str):
+      if isinstance(arg, basestring):
         return '"%s"' % arg
       else:
         return str(arg)

--- a/flexmock_test.py
+++ b/flexmock_test.py
@@ -1,3 +1,4 @@
+#-*- coding: utf8 -*-
 from flexmock import FlexMock
 from flexmock import AlreadyMocked
 from flexmock import AndExecuteNotSupportedForClassMocks
@@ -808,6 +809,13 @@ class TestFlexmock(unittest.TestCase):
       assert True
       return
     assert False
+
+  def test_flexmock_should_not_explode_on_unicode_formatting(self):
+    """
+    To make sure flexmock properly formats method signatures containing unicode arguments
+    """
+    formatted = FlexMock._format_args('method', {'kargs' : (u'嘢',), 'kwargs' : {}})
+    assert formatted == u'method("嘢")'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey, just wanted to submit a small bug fix for a bug I hit while using flexmock. If a method took any arguments that were unicode objects, they weren't treated as strings in Flexmock._format_args, and it would explode since it'd attempt to encode them as ascii (which would fail if you were using non-ascii chars). I just swapped the check to use basestring instead of str to fix this. 

Awesome library btw, first mocking package I've actually used due to how intuitive (and easy) it was to use. Many thanks for sharing it.
