### PR TITLE
Pass thru dup call bug

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -568,7 +568,7 @@ class FlexMock(object):
                                   return_values)):
         raise (InvalidMethodSignature('expected to return %s, returned %s' %
                (expectation.return_values[0].value, return_values)))
-      return expectation.original_method(*kargs, **kwargs)
+      return return_values
 
     def mock_method(self, *kargs, **kwargs):
       arguments = {'kargs': kargs, 'kwargs': kwargs}

--- a/flexmock_test.py
+++ b/flexmock_test.py
@@ -830,6 +830,21 @@ class TestFlexmock(unittest.TestCase):
       return_value = ReturnValue(unichr(0x86C7))
       assert unicode(return_value) == unichr(0x86C7)
 
+  def test_pass_thru_should_not_call_orig_twice(self):
+    """
+    Make sure pass_thru doesn't call the original method more than once
+    """
+    class Nyan(object):
+      def __init__(self):
+          self.n = 0
+      def method(self):
+          self.n += 1
+    obj = Nyan()
+    flexmock(obj)
+    obj.should_call('method')
+    obj.method()
+    self.assertEqual(obj.n, 1)
+
   def test_flexmock_should_give_reasonable_error_for_builtins(self):
     try:
       flexmock(object).should_receive('time')


### PR DESCRIPTION
Hey, it's me again. Found another bug while I was writing some tests; seems Flexmock.pass_thru is calling expectation.original_method twice instead of simplying returning return_values like it should.
