### PR TITLE
Flexmock assertions do not run within PyCharm.

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1344,3 +1344,12 @@ def _hook_into_testtools():
   except:
     pass
 _hook_into_testtools()
+
+
+def _hook_into_teamcity_unittest():
+  try:
+    from tcunittest import TeamcityTestResult
+    _patch_test_result(TeamcityTestResult)
+  except:
+    pass
+_hook_into_teamcity_unittest()


### PR DESCRIPTION
Hey there,

I tried using flexmock within PyCharm and it looks like flexmock's assertions are not run.

I've opened up this issue with PyCharm [1], any chance this is a flexmock issue?

Thanks.

[1] http://youtrack.jetbrains.com/issue/PY-8459
