### PR TITLE
Make the flexmock module itself callable.

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1353,3 +1353,23 @@ def _hook_into_teamcity_unittest():
   except:
     pass
 _hook_into_teamcity_unittest()
+
+# Dark magic to make the flexmock module itself callable.
+# So that you can say:
+#   import flexmock
+# instead of:
+#   from flexmock import flexmock
+class _CallableModule(types.ModuleType):
+  def __init__(self):
+    super(_CallableModule, self).__init__('flexmock')
+    self._realmod = sys.modules['flexmock']
+    sys.modules['flexmock'] = self
+    self.__doc__ = flexmock.__doc__
+  def __dir__(self):
+    return dir(self._realmod)
+  def __call__(self, *args, **kw):
+    return self._realmod.flexmock(*args, **kw)
+  def __getattr__(self, attr):
+    return getattr(self._realmod, attr)
+
+_CallableModule()

--- a/tests/flexmock_modern_test.py
+++ b/tests/flexmock_modern_test.py
@@ -1,4 +1,4 @@
-from flexmock import flexmock
+import flexmock
 import sys
 import unittest
 

--- a/tests/flexmock_nose_test.py
+++ b/tests/flexmock_nose_test.py
@@ -1,8 +1,8 @@
 from flexmock import MethodCallError
-from flexmock import flexmock
 from flexmock import flexmock_teardown
 from flexmock_test import assertRaises
 from nose import with_setup
+import flexmock
 import flexmock_test
 import unittest
 
@@ -40,4 +40,3 @@ class TestUnittestClass(flexmock_test.TestFlexmockUnittest):
     a = flexmock(a=2)
     a.should_receive('a').once
     assertRaises(MethodCallError, flexmock_teardown)
-

--- a/tests/flexmock_pytest_test.py
+++ b/tests/flexmock_pytest_test.py
@@ -1,7 +1,7 @@
 from flexmock import MethodCallError
 from flexmock import flexmock_teardown
-from flexmock import flexmock
 from flexmock_test import assertRaises
+import flexmock
 import flexmock_test
 import unittest
 

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -14,10 +14,10 @@ from flexmock import StateError
 from flexmock import MethodCallError
 from flexmock import CallOrderError
 from flexmock import ReturnValue
-from flexmock import flexmock
 from flexmock import flexmock_teardown
 from flexmock import _format_args
 from flexmock import _isproperty
+import flexmock
 import re
 import sys
 import unittest


### PR DESCRIPTION
"import flexmock" instead of "from flexmock import flexmock".

Not sure if serious.
