### PR TITLE
execute pytest call hook only in phase 'call' (fixes issue #92)

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1203,12 +1203,11 @@ def _hook_into_pytest():
     saved = runner.call_runtest_hook
     def call_runtest_hook(item, when, **kwargs):
       ret = saved(item, when, **kwargs)
-      teardown = runner.CallInfo(flexmock_teardown, when=when)
-      if when == 'call' and not ret.excinfo:
-        teardown.result = None
-        return teardown
-      else:
+      if when != 'call' or ret.excinfo is None:
         return ret
+      teardown = runner.CallInfo(flexmock_teardown, when=when)
+      teardown.result = None
+      return teardown
     runner.call_runtest_hook = call_runtest_hook
 
   except ImportError:

--- a/tests/flexmock_pytest_test.py
+++ b/tests/flexmock_pytest_test.py
@@ -4,11 +4,20 @@ from flexmock_test import assertRaises
 import flexmock
 import flexmock_test
 import unittest
+import pytest
 
 
 def test_module_level_test_for_pytest():
   flexmock(foo='bar').should_receive('foo').once
   assertRaises(MethodCallError, flexmock_teardown)
+
+
+@pytest.fixture()
+def runtest_hook_fixture():
+  return flexmock(foo='bar').should_receive('foo').once.mock()
+
+def test_runtest_hook_with_fixture_for_pytest(runtest_hook_fixture):
+  runtest_hook_fixture.foo()
 
 
 class TestForPytest(flexmock_test.RegularClass):


### PR DESCRIPTION
The `call_runtest_hook` installed by flexmock executes the function `flexmock_teardown` on each phase, thus resetting flexmock objects created in test fixtures.

This commit limits the execution of `flexmock_teardown` to the _call_ phase and should fix issue #92.
