### PR TITLE
Make it possible to assign human readable names to mock instances

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -684,6 +684,21 @@ class Mock(object):
     else:
       yield self
 
+  def __repr__(self):
+    mock_info = []
+    if hasattr(self, '_assigned_name'):
+        mock_info.append('name=%s' % getattr(self, '_assigned_name', None))
+    if inspect.isclass(self._object):
+        mock_info.append('spec=%s' % self._object.__name__)
+    if mock_info:
+        return '<%s %s>' % (self.__module__ + "." + self.__class__.__name__, str.join(', ', mock_info))
+
+    return object.__repr__(self)
+
+  def named(self, value):
+    setattr(self, '_assigned_name', value)
+    return self
+
   def should_receive(self, name):
     """Replaces the specified attribute with a fake.
 

--- a/flexmock.py
+++ b/flexmock.py
@@ -691,7 +691,8 @@ class Mock(object):
     if inspect.isclass(self._object):
         mock_info.append('spec=%s' % self._object.__name__)
     if mock_info:
-        return '<%s %s>' % (self.__module__ + "." + self.__class__.__name__, str.join(', ', mock_info))
+        module = '%s.%s' % (self.__module__, self.__class__.__name__)
+        return '<%s %s>' % (module, str.join(', ', mock_info))
 
     return object.__repr__(self)
 

--- a/flexmock.py
+++ b/flexmock.py
@@ -1209,9 +1209,9 @@ def flexmock(*args, **kwargs):
   Returns:
     Mock object if no spec is provided. Otherwise return the spec object.
   """
-  is_spec = lambda arg: type(arg) not in (str, unicode)
-  spec = next((a for a in args if is_spec(a)), None)
-  name = next((a for a in args if not is_spec(a)), None)
+  is_text = lambda arg: type(arg) in (str, unicode)
+  spec = next((arg for arg in args if not is_text(arg)), None)
+  name = next((arg for arg in args if is_text(arg)), None)
   if spec is not None:
     mock = _create_partial_mock(spec, **kwargs)
   else:

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -61,6 +61,11 @@ def assertIn(member, container):
         raise AssertionError('%s not found in %s' % (member, container))
 
 
+def assertNotIn(member, container):
+    if member in container:
+        raise AssertionError('%s found in %s' % (member, container))
+
+
 class RegularClass(object):
 
   def _tear_down(self):
@@ -1588,15 +1593,13 @@ class RegularClass(object):
     assertEqual('bar', foo.bar)
     assertEqual('bar', foo2.bar)
 
-  def test_named_returns_mock_instance(self):
-      mymock = flexmock()
-      assertEqual(mymock, mymock.named('foo'))
-
   def test_can_assign_name_to_mock(self):
-    assertIn('name=foo', repr(flexmock().named('foo')))
+    assertIn('name=foo', repr(flexmock('foo')))
 
-  def test_can_assign_name_to_mock_several_times_but_only_the_last_one_sticks(self):
-    assertIn('name=bar', repr(flexmock().named('foo').named('bar')))
+  def test_does_not_show_name_when_not_set(self):
+    assertNotIn('name=', repr(flexmock()))
+    assertNotIn('name=', repr(flexmock(NewStyleClass)))
+    assertNotIn('name=', repr(flexmock(OldStyleClass)))
 
   def test_repr_includes_type_when_mocking_new_style_class(self):
     assertIn('spec=NewStyleClass', repr(flexmock(NewStyleClass)))
@@ -1606,12 +1609,11 @@ class RegularClass(object):
 
   def test_repr_includes_name_and_type(self):
     class Foo(object): pass
-    assertIn('spec=Foo', repr(flexmock(Foo).named('bar')))
-    assertIn('name=bar', repr(flexmock(Foo).named('bar')))
+    assertIn('spec=Foo', repr(flexmock(Foo, 'bar')))
+    assertIn('name=bar', repr(flexmock(Foo, 'bar')))
     class Bar: pass
-    assertIn('spec=Bar', repr(flexmock(Bar).named('bar')))
-    assertIn('name=bar', repr(flexmock(Bar).named('bar')))
-
+    assertIn('spec=Bar', repr(flexmock(Bar, 'bar')))
+    assertIn('name=bar', repr(flexmock(Bar, 'bar')))
 
 class TestFlexmockUnittest(RegularClass, unittest.TestCase):
   def tearDown(self):

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -1583,6 +1583,44 @@ class RegularClass(object):
     assertEqual('bar', foo.bar)
     assertEqual('bar', foo2.bar)
 
+  def test_named_returns_mock_instance(self):
+      mymock = flexmock()
+      assertEqual(mymock, mymock.named('foo'))
+
+  def test_can_assign_name_to_mock(self):
+    assertEqual(repr(flexmock().named('foo')), '<flexmock.MockClass name=foo>')
+
+  def test_can_assign_name_to_mock_several_times_but_only_the_last_one_sticks(self):
+    assertEqual(repr(flexmock().named('foo').named('bar')), '<flexmock.MockClass name=bar>')
+
+  def test_repr_includes_type_when_mocking_new_style_class(self):
+    assertEqual(repr(flexmock(NewStyleClass)), '<flexmock.Mock spec=NewStyleClass>')
+
+  def test_repr_includes_type_when_mocking_old_style_class(self):
+    assertEqual(repr(flexmock(OldStyleClass)), '<flexmock.Mock spec=OldStyleClass>')
+
+  def test_repr_includes_name_and_type_when_mocking_new_style_class(self):
+    class Foo(object): pass
+    assertEqual(repr(flexmock(Foo).named('bar')), '<flexmock.Mock name=bar, spec=Foo>')
+
+  def test_repr_includes_name_and_type_when_mocking_old_style_class(self):
+    class Foo: pass
+    assertEqual(repr(flexmock(Foo).named('bar')), '<flexmock.Mock name=bar, spec=Foo>')
+
+  def test_new_style_class_level_mock_can_be_named_several_times_but_only_the_last_one_sticks(self):
+    class Foo(object): pass
+    foo = flexmock(Foo).named('foo')
+    bar = flexmock(Foo).named('bar')
+    assertEqual(foo, bar)
+    assertEqual(repr(bar), '<flexmock.Mock name=bar, spec=Foo>')
+
+  def test_old_style_class_level_mock_can_be_named_several_times_but_only_the_last_one_sticks(self):
+    class Foo: pass
+    foo = flexmock(Foo).named('foo')
+    bar = flexmock(Foo).named('bar')
+    assertEqual(foo, bar)
+    assertEqual(repr(bar), '<flexmock.Mock name=bar, spec=Foo>')
+
 
 class TestFlexmockUnittest(RegularClass, unittest.TestCase):
   def tearDown(self):

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -56,6 +56,11 @@ def assertEqual(expected, received, msg=''):
     raise AssertionError('%s != %s : %s' % (expected, received, msg))
 
 
+def assertIn(member, container):
+    if member not in container:
+        raise AssertionError('%s not found in %s' % (member, container))
+
+
 class RegularClass(object):
 
   def _tear_down(self):
@@ -1588,38 +1593,24 @@ class RegularClass(object):
       assertEqual(mymock, mymock.named('foo'))
 
   def test_can_assign_name_to_mock(self):
-    assertEqual(repr(flexmock().named('foo')), '<flexmock.MockClass name=foo>')
+    assertIn('name=foo', repr(flexmock().named('foo')))
 
   def test_can_assign_name_to_mock_several_times_but_only_the_last_one_sticks(self):
-    assertEqual(repr(flexmock().named('foo').named('bar')), '<flexmock.MockClass name=bar>')
+    assertIn('name=bar', repr(flexmock().named('foo').named('bar')))
 
   def test_repr_includes_type_when_mocking_new_style_class(self):
-    assertEqual(repr(flexmock(NewStyleClass)), '<flexmock.Mock spec=NewStyleClass>')
+    assertIn('spec=NewStyleClass', repr(flexmock(NewStyleClass)))
 
   def test_repr_includes_type_when_mocking_old_style_class(self):
-    assertEqual(repr(flexmock(OldStyleClass)), '<flexmock.Mock spec=OldStyleClass>')
+    assertIn('spec=OldStyleClass', repr(flexmock(OldStyleClass)))
 
-  def test_repr_includes_name_and_type_when_mocking_new_style_class(self):
+  def test_repr_includes_name_and_type(self):
     class Foo(object): pass
-    assertEqual(repr(flexmock(Foo).named('bar')), '<flexmock.Mock name=bar, spec=Foo>')
-
-  def test_repr_includes_name_and_type_when_mocking_old_style_class(self):
-    class Foo: pass
-    assertEqual(repr(flexmock(Foo).named('bar')), '<flexmock.Mock name=bar, spec=Foo>')
-
-  def test_new_style_class_level_mock_can_be_named_several_times_but_only_the_last_one_sticks(self):
-    class Foo(object): pass
-    foo = flexmock(Foo).named('foo')
-    bar = flexmock(Foo).named('bar')
-    assertEqual(foo, bar)
-    assertEqual(repr(bar), '<flexmock.Mock name=bar, spec=Foo>')
-
-  def test_old_style_class_level_mock_can_be_named_several_times_but_only_the_last_one_sticks(self):
-    class Foo: pass
-    foo = flexmock(Foo).named('foo')
-    bar = flexmock(Foo).named('bar')
-    assertEqual(foo, bar)
-    assertEqual(repr(bar), '<flexmock.Mock name=bar, spec=Foo>')
+    assertIn('spec=Foo', repr(flexmock(Foo).named('bar')))
+    assertIn('name=bar', repr(flexmock(Foo).named('bar')))
+    class Bar: pass
+    assertIn('spec=Bar', repr(flexmock(Bar).named('bar')))
+    assertIn('name=bar', repr(flexmock(Bar).named('bar')))
 
 
 class TestFlexmockUnittest(RegularClass, unittest.TestCase):


### PR DESCRIPTION
I have been using flexmock for a while now and I would really like to be able to name my mocks. This a suggestion how to implement names.

Consider this failing test 

``` python
def test_foo(self):
    def store(self, database, sql):
        database.execute(database)

    sql = flexmock()
    database = flexmock()

    database.should_receive('execute').with_args(sql).once()
    store(database, sql)
```

This test will fail with the following message.

``` python
MethodSignatureError: execute(<flexmock.MockClass object at 0x109990990>)
```

But with my patch we could write it like this

``` python
sql = flexmock().named('sql  statement')
database = flexmock().named('database')
```

Now the test will fail like this, which is much more helpful.

``` python
MethodSignatureError: execute(<flexmock.MockClass name=database>)
```

Let's say that we want to mock the Person class

``` python
class Person(object):
    def name(self):
        return 'Alice'
```

I did not want to pass the name as a parameter to init on Mock, becuase we could run in to problems if we try to do this:

``` python
flexmock(Person, name="AliceMock")
```

I think that it is much nicer to write

``` python
flexmock(Person).named("AliceMock")
```

Which could give us something like:

``` python
MethodSignatureError: execute(<flexmock.Mock name=AliceMock, spec=Person>)
```

What do you think? Could something like this fit into flexmock?
