### PR TITLE
Fixes for teardown in py.test call hook (issue #98)

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1210,6 +1210,8 @@ def _hook_into_pytest():
         return ret
       teardown = runner.CallInfo(flexmock_teardown, when=when)
       teardown.result = None
+      if ret.excinfo is not None and teardown.excinfo is None:
+          teardown.excinfo = ret.excinfo
       return teardown
     runner.call_runtest_hook = call_runtest_hook
 

--- a/tests/flexmock_pytest_test.py
+++ b/tests/flexmock_pytest_test.py
@@ -33,3 +33,11 @@ class TestUnittestClass(flexmock_test.TestFlexmockUnittest):
     a = flexmock(a=2)
     a.should_receive('a').once
     assertRaises(MethodCallError, flexmock_teardown)
+
+
+class TestFailureOnException(object):
+
+  @pytest.mark.xfail(raises=RuntimeError)
+  def test_exception(self):
+    raise RuntimeError("TEST ERROR")
+


### PR DESCRIPTION
These changes should fix the 2 bugs mentioned in issue #98.
