### PR TITLE
Fix an issue with module-level functions having named parameters

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -311,7 +311,8 @@ class Expectation(object):
     if not argspec:
       return default
     ret = {'kargs': (), 'kwargs': kwargs}
-    if inspect.ismethod(getattr(self._mock, self.name)):
+    if (inspect.ismethod(getattr(self._mock, self.name))
+        and type(self._mock) != types.ModuleType):
       args = argspec.args[1:]
     else:
       args = argspec.args

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -22,6 +22,8 @@ import re
 import sys
 import unittest
 
+import flexmock_testable_functions
+
 
 def module_level_function(some, args):
   return "%s, %s" % (some, args)
@@ -1603,6 +1605,14 @@ class RegularClass(object):
                 'Property bar not cleaned up')
     assertEqual('bar', foo.bar)
     assertEqual('bar', foo2.bar)
+
+  def test_mock_module_method(self):
+    mock = flexmock(flexmock_testable_functions)
+    mock.should_receive('module_func_with_named_args').with_args(
+        1, b=10)
+    assertRaises(MethodSignatureError,
+                 flexmock_testable_functions.module_func_with_named_args,
+                 1, b='fail')
 
 
 class TestFlexmockUnittest(RegularClass, unittest.TestCase):

--- a/tests/flexmock_testable_functions.py
+++ b/tests/flexmock_testable_functions.py
@@ -1,0 +1,2 @@
+def module_func_with_named_args(a, b=1):
+      pass


### PR DESCRIPTION
Module-level functions having at least one named parameter were not correctly verifying expectations. A test is provided that verifies the fix.

I'm not at all confident that this is the correct or best way to solve this, but it does solve it with no apparent regressions.