### PR TITLE
Helpful error message for objects with __slots__

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -1033,7 +1033,7 @@ def _attach_flexmock_methods(mock, flexmock_class, obj):
         'Python does not allow you to mock builtin objects or modules. '
         'Consider wrapping it in a class you can mock instead')
   except AttributeError:
-    if obj.__slots__:
+    if hasattr(obj, '__slots__'):
       raise MockSlotsError(
         'Cannot mock an object with \'__slots__\'. '
         'Consider wrapping it in a class you can mock instead')  

--- a/flexmock.py
+++ b/flexmock.py
@@ -61,6 +61,10 @@ class MockBuiltinError(Exception):
   pass
 
 
+class MockSlotsError(Exception):
+  pass
+
+
 class MethodSignatureError(FlexmockError):
   pass
 
@@ -1029,6 +1033,10 @@ def _attach_flexmock_methods(mock, flexmock_class, obj):
         'Python does not allow you to mock builtin objects or modules. '
         'Consider wrapping it in a class you can mock instead')
   except AttributeError:
+    if obj.__slots__:
+      raise MockSlotsError(
+        'Cannot mock an object with \'__slots__\'.'
+        'Consider wrapping it in a class you can mock instead')  
     raise MockBuiltinError(
         'Python does not allow you to mock instances of builtin objects. '
         'Consider wrapping it in a class you can mock instead')

--- a/flexmock.py
+++ b/flexmock.py
@@ -1035,7 +1035,7 @@ def _attach_flexmock_methods(mock, flexmock_class, obj):
   except AttributeError:
     if obj.__slots__:
       raise MockSlotsError(
-        'Cannot mock an object with \'__slots__\'.'
+        'Cannot mock an object with \'__slots__\'. '
         'Consider wrapping it in a class you can mock instead')  
     raise MockBuiltinError(
         'Python does not allow you to mock instances of builtin objects. '

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -5,6 +5,7 @@ from flexmock import AT_MOST
 from flexmock import UPDATED_ATTRS
 from flexmock import Mock
 from flexmock import MockBuiltinError
+from flexmock import MockSlotsError
 from flexmock import FlexmockContainer
 from flexmock import FlexmockError
 from flexmock import MethodSignatureError
@@ -1022,6 +1023,16 @@ class RegularClass(object):
     flexmock(foo).should_call('method').with_args('bar').once()
     foo.method('foo')
     assertRaises(MethodCallError, self._tear_down)
+
+  def test_should_give_reasonable_error_for_classes_with_slots(self):
+    class SlottedClass(object):
+      __slots__ = ['only_this_attr_allowed']
+    assertRaises(MockSlotsError, flexmock, SlottedClass)
+
+  def test_should_give_reasonable_error_for_instances_of_classes_with_slots(self):
+    class SlottedClass(object):
+      __slots__ = ['only_this_attr_allowed']
+    assertRaises(MockSlotsError, flexmock, SlottedClass())
 
   def test_should_give_reasonable_error_for_builtins(self):
     assertRaises(MockBuiltinError, flexmock, object)


### PR DESCRIPTION
setting __slots__ on a class limits the attributes that can be set so it prevents mocking. Previously the error message was confusing and unhelpful.