### PR TITLE
Improve pypy compatibility.

### DIFF
--- a/flexmock.py
+++ b/flexmock.py
@@ -635,7 +635,8 @@ class Expectation(object):
     if not isinstance(_mock, Mock):
       original = self.__dict__.get('original')
       if original:
-        name = _getattr(self, 'name')
+        # name may be unicode but pypy demands dict keys to be str
+        name = str(_getattr(self, 'name')) 
         if (hasattr(_mock, '__dict__') and
             name in _mock.__dict__ and
             self._local_override):
@@ -1065,6 +1066,7 @@ def _getattr(obj, name):
 
 def _setattr(obj, name, value):
   """Ensure we use local __dict__ where possible."""
+  name = str(name)  # name may be unicode but pypy demands dict keys to be str
   local_override = False
   if hasattr(obj, '__dict__') and type(obj.__dict__) is dict:
     if name not in obj.__dict__:

--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -83,6 +83,15 @@ class RegularClass(object):
     assertEqual('value_bar', mock.method_foo())
     assertEqual('value_baz', mock.method_bar())
 
+  def test_type_flexmock_with_unicode_string_in_should_receive(self):
+    class Foo(object):
+      def bar(self): return 'bar'
+
+    flexmock(Foo).should_receive(u'bar').and_return('mocked_bar')
+
+    foo = Foo()
+    assertEqual('mocked_bar', foo.bar())
+
   def test_flexmock_should_accept_shortcuts_for_creating_mock_object(self):
     mock = flexmock(attr1='value 1', attr2=lambda: 'returning 2')
     assertEqual('value 1', mock.attr1)


### PR DESCRIPTION
PyPy demands keys to be strings (vs unicode).
This causes issues if your best code has something like: `from __future__ import unicode_literals`

I've ran the tests on PyPy and Python 2.7.10