### PR TITLE
Add support for mocking functions with keyword-only args, fixes #100

### DIFF
--- a/tests/flexmock_test.py
+++ b/tests/flexmock_test.py
@@ -1629,6 +1629,28 @@ if sys.version_info >= (2, 6):
     pass
 
 
+if sys.version_info >= (3, 0):
+  import py3_only_features
+
+  class TestPy3Features(unittest.TestCase):
+    def test_mock_kwargs_only_func_mock_all(self):
+      flexmock(py3_only_features).should_receive(
+          'kwargs_only_func').with_args(1, bar=2, baz=3).and_return(123)
+      self.assertEqual(py3_only_features.kwargs_only_func(1, bar=2, baz=3),
+                       123)
+
+    def test_mock_kwargs_only_func_mock_required(self):
+      flexmock(py3_only_features).should_receive(
+          'kwargs_only_func').with_args(1, bar=2).and_return(123)
+      self.assertEqual(py3_only_features.kwargs_only_func(1, bar=2), 123)
+
+    def test_mock_kwargs_only_func_fails_if_required_not_provided(self):
+      self.assertRaises(
+          MethodSignatureError,
+          flexmock(py3_only_features).should_receive(
+              'kwargs_only_func').with_args,
+          1)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/flexmock_unittest_test.py
+++ b/tests/flexmock_unittest_test.py
@@ -6,6 +6,8 @@ from flexmock_test import TestFlexmockUnittest
 if sys.version_info >= (2, 6):
   from flexmock_modern_test import TestFlexmockUnittestModern
 
+if sys.version_info >= (3,0):
+  from flexmock_test import TestPy3Features
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/py3_only_features.py
+++ b/tests/py3_only_features.py
@@ -1,0 +1,2 @@
+def kwargs_only_func(foo, *, bar, baz=5):
+  return foo + bar + baz

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTHON_VERSIONS=${PYTHON_VERSIONS:-"2.4 2.5 2.6 2.7 3.1 3.2 3.3"}
+PYTHON_VERSIONS=${PYTHON_VERSIONS:-"2.4 2.5 2.6 2.7 3.1 3.2 3.3 3.4 3.5"}
 PYTHON_IMPLEMENTATIONS=${PYTHON_IMPLEMENTATIONS:-"cpython pypy jython"}
 RUNNERS=${RUNNERS:-"unittest nose pytest twisted"}
 SCRIPT=$(cd ${0%/*} && echo $PWD/${0##*/})


### PR DESCRIPTION
This PR adds support for using getfullargspec if running in Python 3. I included some basic tests, but I'm not 100 % sure that I did everything right, especially in the `_verify_signature_match`, so it'd be good if you could review this thoroughly before merging.
(I also added 3.4 and 3.5 to run_test.sh to be able to test on these versions.)